### PR TITLE
Account for crossbeam::scope's new return value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,9 +10,9 @@ keywords = ["parallel", "download", "get"]
 categories = ["network-programming"]
 
 [dependencies]
-progress-streams = "1.0.0"
-reqwest = { version = "0.10.4", features = ["blocking"] }
+progress-streams = "1.1.0"
+reqwest = { version = "0.10.8", features = ["blocking"] }
 
-tempfile = "3.0.4"
+tempfile = "3.1.0"
 numtoa = "0.2.3"
-crossbeam = "0.4.1"
+crossbeam = "0.7.3"


### PR DESCRIPTION
Please don't merge yet - I am looking for feedback on lib.rs, line 373 - I'd like to return the original boxed error (`e`) from crossbeam but I have no idea how to do that. Any advice appreciated!